### PR TITLE
feat: Enable self-location sharing from God View

### DIFF
--- a/godview_script.js
+++ b/godview_script.js
@@ -1,32 +1,109 @@
 document.addEventListener('DOMContentLoaded', function() {
     const locationContentDiv = document.getElementById('god-view-content');
+    // Prepare for a status div (will be added to index.html in next step)
+    // For now, we can assume it might exist, or messages can be logged if it doesn't.
+    // A better approach is to get this element in the next step when it's created.
+    // For this subtask, we'll focus on the logic and assume a 'self-location-status' div.
+    const selfLocationStatusDiv = document.getElementById('self-location-status'); // Will be added in HTML later
 
-    if (!locationContentDiv) {
-        console.error('Error: god-view-content div not found!');
-        return;
+    function updateSelfLocationStatus(message, isError = false) {
+        if (selfLocationStatusDiv) {
+            selfLocationStatusDiv.innerHTML = message;
+            selfLocationStatusDiv.style.color = isError ? 'red' : 'green';
+        } else {
+            // Fallback if div not yet there (though it should be by the time this is called if plan followed)
+            isError ? console.error(message) : console.log(message);
+        }
     }
 
-    // Check if Firebase is available
+    function shareSelfLocation() {
+        const userName = prompt("Please enter your name to share your location on the God View:", "");
+        if (!userName || userName.trim() === "") {
+            updateSelfLocationStatus("Name not provided. Your location will not be shared.", true);
+            return;
+        }
+
+        if (navigator.geolocation) {
+            updateSelfLocationStatus(`Attempting to share your location as ${userName.trim()}...`);
+            navigator.geolocation.getCurrentPosition(
+                (position) => handleSelfPosition(position, userName.trim()),
+                handleSelfError,
+                { enableHighAccuracy: true, timeout: 10000, maximumAge: 0 }
+            );
+        } else {
+            updateSelfLocationStatus("Geolocation is not supported by this browser. Cannot share your location.", true);
+        }
+    }
+
+    function handleSelfPosition(position, userName) {
+        const lat = position.coords.latitude;
+        const lon = position.coords.longitude;
+        const acc = position.coords.accuracy;
+        const timestamp = new Date().toISOString();
+
+        const locationData = {
+            name: userName,
+            latitude: lat,
+            longitude: lon,
+            accuracy: acc,
+            last_updated: timestamp,
+            notes: "User of God View" // Optional note
+        };
+
+        firebase.database().ref('locations/' + userName).set(locationData)
+            .then(() => {
+                updateSelfLocationStatus(`Your location as ${userName} is now being shared.`, false);
+            })
+            .catch((error) => {
+                console.error('Firebase write error (self-location):', error);
+                updateSelfLocationStatus(`Error sharing your location: ${error.message}`, true);
+            });
+    }
+
+    function handleSelfError(error) {
+        let message = '';
+        switch(error.code) {
+            case error.PERMISSION_DENIED: message = "Permission denied for Geolocation."; break;
+            case error.POSITION_UNAVAILABLE: message = "Location information unavailable."; break;
+            case error.TIMEOUT: message = "Geolocation request timed out."; break;
+            default: message = "An unknown error occurred during geolocation."; break;
+        }
+        updateSelfLocationStatus(`Could not share your location: ${message}`, true);
+    }
+
+    // --- Start of existing godview_script.js logic ---
+    if (!locationContentDiv) {
+        console.error('Error: god-view-content div not found!');
+        return; // Critical error for main functionality
+    }
+
     if (typeof firebase === 'undefined' || typeof firebase.database === 'undefined') {
         console.error('Firebase SDK not loaded or Realtime Database module missing.');
         locationContentDiv.innerHTML = '<p style="color: red;">Error: Firebase connection not set up. Cannot display locations.</p>';
-        return;
+        if (selfLocationStatusDiv) selfLocationStatusDiv.innerHTML = ''; // Clear any self-status if main fails
+        return; // Critical error for main functionality
     }
     const database = firebase.database();
     const locationsRef = database.ref('locations');
 
-    locationContentDiv.innerHTML = '<p>Loading location data from Firebase...</p>';
+    // Attempt to share self location first
+    shareSelfLocation(); // Call the new function to attempt self-location sharing
+
+    // Then proceed with displaying all locations
+    locationContentDiv.innerHTML = '<p>Loading all location data from Firebase...</p>';
 
     locationsRef.on('value', (snapshot) => {
         const locationsData = snapshot.val();
+        // ... (rest of the existing locationsRef.on('value', ...) logic remains unchanged) ...
+        // Make sure this existing logic correctly clears and rebuilds the list.
+        // For example, ensure it starts with locationContentDiv.innerHTML = ''; or similar if locationsData is present.
         if (locationsData) {
             let htmlContent = '<ul>';
-            Object.keys(locationsData).forEach(userName => {
-                const person = locationsData[userName];
-                // Validate essential data for display
+            Object.keys(locationsData).forEach(keyName => { // Changed userName to keyName to avoid conflict
+                const person = locationsData[keyName];
                 if (!person || typeof person.name === 'undefined') {
-                    console.warn('Skipping invalid location entry for key:', userName, person);
-                    return; // skip this entry
+                    console.warn('Skipping invalid location entry for key:', keyName, person);
+                    return; 
                 }
 
                 htmlContent += `<li>`;
@@ -45,10 +122,10 @@ document.addEventListener('DOMContentLoaded', function() {
             htmlContent += '</ul>';
             locationContentDiv.innerHTML = htmlContent;
         } else {
-            locationContentDiv.innerHTML = '<p>No location data available in Firebase. Waiting for team members to report their locations.</p>';
+            locationContentDiv.innerHTML = '<p>No location data available in Firebase. Waiting for team members to report their locations (or for you to share yours).</p>';
         }
     }, (error) => {
-        console.error('Firebase read error:', error);
+        console.error('Firebase read error (all locations):', error);
         locationContentDiv.innerHTML = `<p style="color: red;">Error fetching data from Firebase: ${error.message}</p>`;
     });
 });

--- a/index.html
+++ b/index.html
@@ -8,6 +8,7 @@
 </head>
 <body>
     <h1>Scioly Team Tracker - God View</h1>
+    <div id="self-location-status" style="text-align: center; padding: 5px; min-height: 1.2em;"></div>
     <div id="god-view-content">
         <!-- Location data will be loaded here by JavaScript -->
     </div>


### PR DESCRIPTION
Allows you, when viewing the `index.html` (God View) page, to also share your own location.

Key changes:
- Modified `godview_script.js`:
    - On page load, I'll prompt you for your name.
    - If a name is provided, I'll attempt to get your geolocation.
    - If successful, I'll write the location data (name, lat, lon, accuracy, timestamp) to `/locations/{userName}` in Firebase.
    - This makes your location visible to others on the map.
    - Includes error handling and status messages.
- Modified `index.html`:
    - Added a new `div` with ID `self-location-status`.
    - This div displays feedback to you about the status of your own location sharing (e.g., "Sharing your location as [User]...", "Error: Permission denied.").

This feature enhances the God View by allowing anyone viewing it to also optionally appear on the map, fostering a more interconnected view of all participants.