### PR TITLE
Add login portal with hashed password auth

### DIFF
--- a/firebase-config.js
+++ b/firebase-config.js
@@ -26,6 +26,6 @@ try {
 // import { getAnalytics } from "firebase/analytics";
 // const analytics = getAnalytics(app);
 
-// Make the database reference available if needed globally by other scripts,
-// though it's often better to get it specifically where needed.
-// const database = firebase.database();
+// Make Firebase services easily accessible in other scripts if needed
+const database = firebase.database();
+const auth = firebase.auth();

--- a/index.html
+++ b/index.html
@@ -36,5 +36,9 @@
     <!-- Your existing script -->
     <script src="godview_script.js"></script>
     <script src="chat_script.js"></script>
+
+    <p style="text-align:center; margin-top:20px;">
+        <a href="login.html">User Login</a>
+    </p>
 </body>
 </html>

--- a/login.html
+++ b/login.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>User Authentication</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <h1>User Authentication</h1>
+    <div id="auth-container">
+        <input type="email" id="email" placeholder="Email">
+        <input type="password" id="password" placeholder="Password">
+        <div id="auth-buttons">
+            <button id="sign-up">Sign Up</button>
+            <button id="sign-in">Sign In</button>
+        </div>
+        <div id="status"></div>
+    </div>
+
+    <!-- Firebase SDKs -->
+    <script src="https://www.gstatic.com/firebasejs/9.6.1/firebase-app-compat.js"></script>
+    <script src="https://www.gstatic.com/firebasejs/9.6.1/firebase-auth-compat.js"></script>
+    <script src="firebase-config.js"></script>
+    <script src="login_script.js"></script>
+</body>
+</html>

--- a/login_script.js
+++ b/login_script.js
@@ -1,0 +1,56 @@
+document.addEventListener('DOMContentLoaded', function() {
+    const emailInput = document.getElementById('email');
+    const passwordInput = document.getElementById('password');
+    const signUpButton = document.getElementById('sign-up');
+    const signInButton = document.getElementById('sign-in');
+    const statusDiv = document.getElementById('status');
+
+    async function hashPassword(password) {
+        const enc = new TextEncoder();
+        const buffer = await crypto.subtle.digest('SHA-256', enc.encode(password));
+        return Array.from(new Uint8Array(buffer))
+            .map(b => b.toString(16).padStart(2, '0'))
+            .join('');
+    }
+
+    signUpButton.addEventListener('click', async () => {
+        const email = emailInput.value.trim();
+        const password = passwordInput.value;
+        if (!email || !password) {
+            statusDiv.textContent = 'Email and password required.';
+            statusDiv.style.color = 'red';
+            return;
+        }
+        try {
+            const hashed = await hashPassword(password);
+            await firebase.auth().createUserWithEmailAndPassword(email, hashed);
+            statusDiv.textContent = 'Sign-up successful.';
+            statusDiv.style.color = 'green';
+        } catch (err) {
+            statusDiv.textContent = 'Error: ' + err.message;
+            statusDiv.style.color = 'red';
+        }
+    });
+
+    signInButton.addEventListener('click', async () => {
+        const email = emailInput.value.trim();
+        const password = passwordInput.value;
+        if (!email || !password) {
+            statusDiv.textContent = 'Email and password required.';
+            statusDiv.style.color = 'red';
+            return;
+        }
+        try {
+            const hashed = await hashPassword(password);
+            await firebase.auth().signInWithEmailAndPassword(email, hashed);
+            statusDiv.textContent = 'Sign-in successful. Redirecting...';
+            statusDiv.style.color = 'green';
+            setTimeout(() => {
+                window.location.href = 'index.html';
+            }, 1000);
+        } catch (err) {
+            statusDiv.textContent = 'Error: ' + err.message;
+            statusDiv.style.color = 'red';
+        }
+    });
+});

--- a/style.css
+++ b/style.css
@@ -128,3 +128,33 @@ button {
 button:hover {
   background-color: #0b8f6d;
 }
+
+#auth-container {
+  max-width: 400px;
+  margin: 100px auto;
+  background-color: var(--panel-bg);
+  padding: 20px;
+  border-radius: 8px;
+  box-shadow: 0 2px 10px rgba(0,0,0,0.6);
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+#auth-container input {
+  padding: 10px;
+  border: 1px solid var(--border-color);
+  border-radius: 8px;
+  background-color: #1e1e20;
+  color: var(--text-color);
+}
+
+#auth-buttons {
+  display: flex;
+  justify-content: space-between;
+}
+
+#status {
+  margin-top: 10px;
+  text-align: center;
+}


### PR DESCRIPTION
## Summary
- add a simple login page that uses Firebase Auth
- hash passwords client side before calling Firebase
- expose `database` and `auth` in the Firebase config
- link to the new login portal from the dashboard
- style the login form

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68410a5499a0832498d1c72b44301033